### PR TITLE
RMB-588: Fix Maven ${} variable replacement in src/main/resources

### DIFF
--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -59,14 +59,8 @@
   </dependencies>
 
   <build>
-    <resources>
-      <resource>
-        <directory>src/main/resources</directory>
-        <filtering>true</filtering>
-      </resource>
-    </resources>
-
     <plugins>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>


### PR DESCRIPTION
Remove this unneccessary and dangerous variable replacement ("variable filtering").
See https://issues.folio.org/browse/FOLIO-2548